### PR TITLE
allow to use with Browserify with brfs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
-require("fs").readdirSync("./src").forEach(function(file) {
-    require("./src/" + file);
+require("fs").readdirSync(__dirname + "/src").forEach(function(file) {
+    require(__dirname + "/src/" + file);
 });


### PR DESCRIPTION
brfs can't really read `"./src"` but it understands `__dirname + "/src"`.
