### PR TITLE
Replace JSON.stringify() with jasmine.pp() [Fixes #9]

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,11 +21,7 @@ beforeEach(function() {
 beforeEach(function() {
     'use strict';
     function stringify(entity) {
-        try {
-            return JSON.stringify(entity);
-        } catch(e) {
-            return entity;
-        }
+        return jasmine.pp(entity);
     }
     jasmine.addMatchers({
         toHaveSameItems: function(util, customEqualityTesters) {
@@ -136,7 +132,7 @@ beforeEach(function() {
             }
             function craftMessage(duplicates, pass) {
                 return pass ? 'All items in the array are unique' : 'Array contains duplicates: \n'+duplicates.map(function(dupe) {
-                    return JSON.stringify(dupe[2])+' at '+dupe[0]+' and '+dupe[1];
+                    return jasmine.pp(dupe[2])+' at '+dupe[0]+' and '+dupe[1];
                 }).join('\n');
             }
             return {

--- a/src/toHaveSameItems.js
+++ b/src/toHaveSameItems.js
@@ -1,11 +1,7 @@
 beforeEach(function() {
     'use strict';
     function stringify(entity) {
-        try {
-            return JSON.stringify(entity);
-        } catch(e) {
-            return entity;
-        }
+        return jasmine.pp(entity);
     }
     jasmine.addMatchers({
         toHaveSameItems: function(util, customEqualityTesters) {

--- a/src/toHaveUniqueItems.js
+++ b/src/toHaveUniqueItems.js
@@ -12,7 +12,7 @@ beforeEach(function() {
             }
             function craftMessage(duplicates, pass) {
                 return pass ? 'All items in the array are unique' : 'Array contains duplicates: \n'+duplicates.map(function(dupe) {
-                    return JSON.stringify(dupe[2])+' at '+dupe[0]+' and '+dupe[1];
+                    return jasmine.pp(dupe[2])+' at '+dupe[0]+' and '+dupe[1];
                 }).join('\n');
             }
             return {


### PR DESCRIPTION
- Replace `JSON.stringify()` with `jasmine.pp()` for more robust collection representations.
- Compile changes.
